### PR TITLE
Check player inventory before moving through restricted exits

### DIFF
--- a/adventure.go
+++ b/adventure.go
@@ -28,6 +28,7 @@ type Room struct {
 	Items       map[string]*Item
 	Visited     bool
 	Exits       []string // outbound connection room names
+	ExitItems   []string // items required to exit a room
 }
 
 // struct used for both features and objects

--- a/parser.go
+++ b/parser.go
@@ -73,6 +73,13 @@ func listInventory() {
 
 // moveToRoom takes a requested exit and moves the player there if the exit exists
 func moveToRoom(exit string) {
+	b := checkExit() // verify we have items needed to leave
+	if !b {
+		// TODO rooms with exit restrictions each have a unique restriction
+		fmt.Println("You need to find an item before you can leave.")
+		return
+	}
+
 	for _, e := range curRoom.Exits {
 		if e == exit { // check that requested exit is valid
 			if val, ok := rooms[exit]; ok {
@@ -96,6 +103,17 @@ func moveToRoom(exit string) {
 		}
 	}
 	fmt.Printf("%s is not a valid exit\n", exit)
+}
+
+// checkExit verifies the player has the item necessary to exit a room
+func checkExit() bool {
+	if len(curRoom.ExitItems) != 0 {
+		obj := curRoom.ExitItems[0]
+		if _, ok := inventory[obj]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // help prints a subset of verbs the game understands

--- a/rooms/attic.json
+++ b/rooms/attic.json
@@ -45,5 +45,6 @@
     }
   },
   "visited": true,
-  "exits": [ "Upstairs Hallway" ]
+  "exits": [ "Upstairs Hallway" ],
+  "exitItems": [ "thread" ]
 }

--- a/rooms/basement_lab.json
+++ b/rooms/basement_lab.json
@@ -45,5 +45,6 @@
     }
   },
   "visited" : false,
-  "exits": [ "Yard" ]
+  "exits": [ "Yard" ],
+  "exitItems": [ "dog whistle" ]
 }


### PR DESCRIPTION
Some room exits require that the player must have an item in
inventory before they can leave. Let's enforce these constraints!

The room struct now has a new filed ExitItems, which contain a list of
items the player must have before they can leave.

A new function checkExit() will check the player's inventory. If a room
has required exit items, the player will not be allowed to exit without the
item in their possession.

In a bigger map, with multiple exits requiring different items, this
would surely have the potential to get messy. But let's not worry about
such things right now!