### PR TITLE
Fix bug in exit check

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -107,12 +107,15 @@ func moveToRoom(exit string) {
 
 // checkExit verifies the player has the item necessary to exit a room
 func checkExit() bool {
-	if len(curRoom.ExitItems) != 0 {
-		obj := curRoom.ExitItems[0]
-		if _, ok := inventory[obj]; ok {
-			return true
-		}
+	if len(curRoom.ExitItems) == 0 {
+		return true
 	}
+
+	obj := curRoom.ExitItems[0]
+	if _, ok := inventory[obj]; ok {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
The first iteration had a bug where the only opportunity to return true
was if the current room required an item to exit. The default case was
always false, resulting in a Hotel California situation.

The fix is to check first if no items are needed (this is the hot path)
and return immediately. If not, only then do we check for a required
item. And if the required item is not inventory, only then do we return
false.