### PR TITLE
Teach parser to understand room aliases

### DIFF
--- a/adventure.go
+++ b/adventure.go
@@ -16,8 +16,9 @@ import (
 const MinRooms = 15
 const MinItems = 8
 
-var rooms = make(map[string]*Room)     // map of rooms
-var inventory = make(map[string]*Item) // player inventory
+var rooms = make(map[string]*Room)        // map of rooms
+var roomAliases = make(map[string]string) // map of room name aliases
+var inventory = make(map[string]*Item)    // player inventory
 var curRoom *Room
 
 // definition of a room

--- a/adventure.go
+++ b/adventure.go
@@ -23,6 +23,7 @@ var curRoom *Room
 // definition of a room
 type Room struct {
 	Name        string
+	Alias       string // regex for room name alias
 	LongDesc    string
 	Description string
 	Items       map[string]*Item
@@ -73,6 +74,12 @@ func loadRooms() {
 			var r Room
 			json.Unmarshal([]byte(roomJson), &r)
 			rooms[r.Name] = &r
+		}
+	}
+
+	for _, r := range rooms {
+		if r.Alias != "" {
+			roomAliases[r.Alias] = r.Name
 		}
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 )
 
@@ -76,6 +77,15 @@ func moveToRoom(exit string) {
 	if !b {
 		fmt.Printf("You cannot leave because %s.\n", curRoom.ExitBlock)
 		return
+	}
+
+	// If the exit requested by a user matches an entry in the list of
+	// room aliases, then the room name becomes the requested exit.
+	for key, val := range roomAliases {
+		matched, _ := regexp.MatchString(key, exit)
+		if matched == true {
+			exit = val
+		}
 	}
 
 	for _, e := range curRoom.Exits {

--- a/rooms/small_bedroom.json
+++ b/rooms/small_bedroom.json
@@ -1,5 +1,6 @@
 {
   "name": "Small Bedroom",
+  "alias": "My|Your Bedroom",
   "longDesc": "You are in the small bedroom, which belongs to you.\nThere is an exit to the upstairs hallway.\nThere is a bed against the wall. You store your treasures underneath it.\nThere is a bedside table with a lamp next next to the head of your bed.\nYour closet is on the wall.\nIt has a chute that leads to the basement where the laundry room is.\nThere are dirty socks on the floor of your closet.\n",
   "description": "You are in the small bedroom, which belongs to you.\nThere is an exit to the upstairs hallway.\nYour closet has a chute that leads to the basement.\n",
   "items": {


### PR DESCRIPTION
Add an alias field to the room structure. 

We can now parse alternate names for rooms like "my bedroom" or "your bedroom".