### PR TITLE
Rooms without verbs

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -496,12 +496,14 @@ Is there anything you could TAKE to help you? Why don't you try to LOOK around?`
 		r := strings.Title(action)
 		if _, ok := rooms[r]; ok {
 			moveToRoom(r)
+			fmt.Print("> ")
 			continue
 		}
 
 		s := strings.Fields(action)
 
 		if cap(s) == 0 {
+			fmt.Print("> ")
 			continue
 		}
 

--- a/parser.go
+++ b/parser.go
@@ -490,7 +490,9 @@ Is there anything you could TAKE to help you? Why don't you try to LOOK around?`
 	for input.Scan() {
 		// split user input at whitespace and match known commands
 		action := input.Text()
-		s := strings.Fields(strings.ToLower(action))
+		action = strings.ToLower(action)
+
+		s := strings.Fields(action)
 
 		if cap(s) == 0 {
 			continue

--- a/parser.go
+++ b/parser.go
@@ -492,6 +492,13 @@ Is there anything you could TAKE to help you? Why don't you try to LOOK around?`
 		action := input.Text()
 		action = strings.ToLower(action)
 
+		// accept just the room name as input
+		r := strings.Title(action)
+		if _, ok := rooms[r]; ok {
+			moveToRoom(r)
+			continue
+		}
+
 		s := strings.Fields(action)
 
 		if cap(s) == 0 {


### PR DESCRIPTION
Who has time to type 'go'? It's a whole extra word! Now the player can type just the name of the room they want to go to without the annoyance of using a verb. 